### PR TITLE
PSPLASH: fix image drawing when size matches display

### DIFF
--- a/recipes-core/psplash/psplash-drm/basic_splash_drm.c
+++ b/recipes-core/psplash/psplash-drm/basic_splash_drm.c
@@ -1120,7 +1120,7 @@ next:
 
             x = (iter->width - img_width) / 2;
             y = (iter->height - img_height) / 2;
-            if ((img_width < iter->width) && (img_height < iter->height) )
+            if ((img_width <= iter->width) && (img_height <= iter->height) )
                 splash_draw_image_for_modeset32 (iter, x, y, img_width, img_height,
                     (uint32_t *)pixman_image_get_data(pixman_image));
             else {


### PR DESCRIPTION
The current logic only draws the splash image if its dimensions are strictly smaller than the display resolution. This causes the image to be skipped if it perfectly matches the screen size.